### PR TITLE
Context filename

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+.nyc_output

--- a/lib/index.js
+++ b/lib/index.js
@@ -4,7 +4,7 @@ const path = require('path')
 module.exports = function reshapeLayouts (options = {}) {
   return function layoutsPlugin (tree, ctx) {
     options.encoding = options.encoding || 'utf8'
-    if (!options.root && ctx.filename) {
+    if (ctx.filename) {
       options.root = path.dirname(ctx.filename)
     }
     options.root = options.root || './'

--- a/lib/index.js
+++ b/lib/index.js
@@ -2,9 +2,10 @@ const fs = require('fs')
 const path = require('path')
 
 module.exports = function reshapeLayouts (options = {}) {
+  const root = options.root
   return function layoutsPlugin (tree, ctx) {
     options.encoding = options.encoding || 'utf8'
-    if (ctx.filename) {
+    if (!root && ctx.filename) {
       options.root = path.dirname(ctx.filename)
     }
     options.root = options.root || './'


### PR DESCRIPTION
This fixes an issue where setting `options.root` to the filename context (https://github.com/reshape/layouts/blob/master/lib/index.js#L8) would override use of the context filename on subsequent requests to resolve layouts when no `root` option is given.

For example, by assigning the context filename to `options.root` (when no `root` option is specified) it would never be called again - the root is set to the first file processed and used by all subsequent files.

This ensures all layouts are resolved correctly when no `root` option is given.

Also updated the `.gitignore` for the code coverage output directory.