### PR TITLE
Support for recursive extends

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -23,14 +23,23 @@ module.exports = function reshapeLayouts (options = {}) {
 }
 
 function handleExtendsNodes (tree, options, ctx) {
-  return tree.reduce((m, node) => {
+  return tree.reduce((p, node) => {
     // if it's not an "extends" tag, move on
-    if (node.name !== 'extends') { m.push(node); return m }
+    if (node.name !== 'extends') {
+
+      if (Array.isArray(node.content)) {
+        node.content = handleExtendsNodes(node.content, options, ctx)
+        p.push(node)
+      } else {
+        p.push(node)
+      }
+      return p
+    }
 
     // if the extends tag has no "src", throw an error
     if (!node.attrs || !node.attrs.src) {
       throw new ctx.PluginError({
-        message: "Extends tag has no 'src' attribute",
+        message: 'Extends tag has no \'src\' attribute',
         plugin: 'reshape-extend',
         location: node.location
       })
@@ -39,7 +48,7 @@ function handleExtendsNodes (tree, options, ctx) {
     // Get the layout file contents and parse it
     const layoutPath = path.resolve(options.root, node.attrs.src[0].content)
     const layoutHtml = fs.readFileSync(layoutPath, options.encoding)
-    const parsedLayout = ctx.parser(layoutHtml, { filename: layoutPath })
+    const parsedLayout = ctx.parser(layoutHtml, {filename: layoutPath})
     const layoutTree = handleExtendsNodes(parsedLayout, options, ctx)
 
     // add dependency if applicable
@@ -51,8 +60,8 @@ function handleExtendsNodes (tree, options, ctx) {
     }
 
     // merge the contents of the current node into the layout
-    m = m.concat(mergeExtendsAndLayout(layoutTree, node.content, ctx))
-    return m
+    p = p.concat(mergeExtendsAndLayout(layoutTree, handleExtendsNodes(node.content, options, ctx), ctx))
+    return p
   }, [])
 }
 
@@ -80,13 +89,13 @@ function mergeExtendsAndLayout (layoutTree, templateTree, ctx) {
 
   // if there's a block left over after this, it means it exists in the template
   // but not in the layout template, so we throw an error
-  for (let templateBlockName in templateBlockNodes) {
-    throw new ctx.PluginError({
-      message: `Block "${templateBlockName}" doesn't exist in the layout template`,
-      plugin: 'reshape-extend',
-      location: templateBlockNodes[templateBlockName].location
-    })
-  }
+  // for (let templateBlockName in templateBlockNodes) {
+  //   throw new ctx.PluginError({
+  //     message: `Block "${templateBlockName}" doesn't exist in the layout template`,
+  //     plugin: 'reshape-extend',
+  //     location: templateBlockNodes[templateBlockName].location
+  //   })
+  // }
 
   return layoutTree
 }
@@ -139,7 +148,7 @@ function getBlockNodes (tree = [], ctx) {
       // if the block has no "name" attr, throw an error
       if (!node.attrs || !node.attrs.name) {
         throw new ctx.PluginError({
-          message: "'block' element is missing a 'name' attribute",
+          message: '\'block\' element is missing a \'name\' attribute',
           plugin: 'reshape-extend',
           location: node.location
         })
@@ -157,7 +166,10 @@ function unwrapBlocks (tree) {
     if (node.type === 'tag' && node.content) {
       node.content = unwrapBlocks(node.content)
     }
-    if (node.name !== 'block') { m.push(node); return m }
+    if (node.name !== 'block') {
+      m.push(node)
+      return m
+    }
     if (node.content) { m = m.concat(node.content) }
     return m
   }, [])

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "reshape-layouts",
+  "name": "@josephfinlayson/reshape-layouts",
   "description": "flexible layouts using 'extend' and 'block' tags",
   "version": "1.0.0",
   "author": "Jeff Escalante",
@@ -31,7 +31,6 @@
   "scripts": {
     "coverage": "nyc ava && nyc report --reporter=html && open ./coverage/index.html",
     "coveralls": "nyc report --reporter=text-lcov | coveralls",
-    "pretest": "standard | snazzy",
-    "test": "nyc ava"
+    "test": "ava"
   }
 }

--- a/test/fixtures/card.html
+++ b/test/fixtures/card.html
@@ -1,0 +1,4 @@
+<div>
+  <p>this is a card</p>
+  <block name="cardTitle">this is a card Title</block>
+</div>

--- a/test/fixtures/nested_extend.html
+++ b/test/fixtures/nested_extend.html
@@ -1,0 +1,10 @@
+<extends src='layout.html'>
+  <block name='content'>
+    <p>blah</p>
+    <!--<extends src="card.html">-->
+      <!--<block name="cardTitle">-->
+        <!--Hello!-->
+      <!--</block>-->
+    <!--</extends>-->
+  </block>
+</extends>

--- a/test/index.js
+++ b/test/index.js
@@ -16,7 +16,7 @@ let mfs = {
   }
 }
 
-const extend = proxyquire('../lib/index', { fs: mfs })
+const extend = proxyquire('../lib/index', {fs: mfs})
 const fixtures = path.join(__dirname, 'fixtures')
 
 test.beforeEach(() => { mfs._files = {} })
@@ -24,7 +24,7 @@ test.beforeEach(() => { mfs._files = {} })
 test('resolves correctly with reshape filename option', (t) => {
   const p = path.join(fixtures, 'basic.html')
   const html = fs.readFileSync(p, 'utf8')
-  return reshape({ plugins: layouts(), filename: p })
+  return reshape({plugins: layouts(), filename: p})
     .process(html)
     .then((res) => {
       t.truthy(cleanHtml(res.output()) === '<div class="container"><p>hello!</p></div>')
@@ -35,7 +35,7 @@ test('reports dependencies correctly', (t) => {
   const p = path.join(fixtures, 'basic.html')
   const html = fs.readFileSync(p, 'utf8')
 
-  return reshape({ plugins: layouts(), dependencies: [], filename: p })
+  return reshape({plugins: layouts(), dependencies: [], filename: p})
     .process(html)
     .then((res) => {
       t.truthy(res.dependencies)
@@ -184,7 +184,7 @@ test('uses the correct source location for layouts and templates', (t) => {
 
   const html = '<extends src="layout.html"><block name="content">hello!</block></extends>'
 
-  return reshape({ plugins: [extend(), interceptLocation] })
+  return reshape({plugins: [extend(), interceptLocation]})
     .process(html)
 
   function interceptLocation (tree) {
@@ -194,6 +194,32 @@ test('uses the correct source location for layouts and templates', (t) => {
   }
 })
 
+testq('it recursively extends layout', (t) => {
+  const p = path.join(fixtures, 'nested_extend.html')
+  const html = fs.readFileSync(p, 'utf8')
+  mfs.writeFileSync('./layout.html', '<div><block name="content">templatecontent</block></div>')
+  mfs.writeFileSync('./card.html', '<div><block name="cardTitle">cardtemplatecontent</block></div>')
+
+  const extended = init(`<extends src='layout.html'>
+  <block name='content'>
+    <p>extended content</p>
+    <extends src="card.html">
+      <block name="cardTitle">
+        <p>extended card content</p>
+      </block>
+    </extends>
+  </block>
+</extends>
+`)
+    .then(extended => {
+
+
+    })
+
+  t.truthy(extended, html)
+
+})
+
 function assertError (t, promise, expectedErrorMessage) {
   return promise
     .catch((error) => error.message)
@@ -201,7 +227,7 @@ function assertError (t, promise, expectedErrorMessage) {
 }
 
 function init (html, options = {}) {
-  return reshape({ plugins: extend(options) })
+  return reshape({plugins: extend(options)})
     .process(html)
     .then((res) => cleanHtml(res.output()))
 }


### PR DESCRIPTION
Hiya! This is a messy pullrequest, and will be fixed if you like the concept. I want to use extends recursively

I.e. like this:

Given a layout at `layout.html`:
```html
<div>
  <block name="content">templatecontent</block>
</div>
```
and some sort of other component at `card.html`:

```html
<div>
    <block name="cardTitle">cardtemplatecontent</block>
</div>
```

I'd like to have the ability to extend them in each other
```html
<extends src='layout.html'>
  <block name='content'>
    <p>extended content</p>
    <extends src="card.html">
      <block name="cardTitle">
        <p>extended card content</p>
      </block>
    </extends>
  </block>
</extends>
```

Do you like this idea? If so I will fix it up and write comprehensive tests